### PR TITLE
Fixed crash when not enough arguments given

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ namespace Earlz.Inceptor
             if(args.Count() != 4)
             {
                 Console.WriteLine("usage: target.dll inceptor.dll saveto.dll methodnames.txt");
+                return;
             }
             var targetModule = ModuleDefinition.ReadModule(args[0]);
             var inceptorModule = ModuleDefinition.ReadModule(args[1]);


### PR DESCRIPTION
I see you're checking whether or not enough arguments were given, but you forgot to add a `return;` for if there aren't. Instead, after telling the user the correct syntax, it continues anyway, indexing the `args` array out of range.
